### PR TITLE
feat(shortcuts): add keyboard shortcuts menu and vim-style navigation

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4,12 +4,14 @@ import { PlanningView } from "./components/planning/PlanningView";
 import { ExecutionView } from "./components/execution/ExecutionView";
 import { AgentsPanel } from "./components/agents/AgentsPanel";
 import { CommandPalette } from "./components/command-palette";
+import { ShortcutsMenu } from "./components/shortcuts/ShortcutsMenu";
 import { WidgetDemo } from "./components/demo/WidgetDemo";
 import { WorkspaceDemo } from "./components/demo/WorkspaceDemo";
 import { Workspace } from "./components/workspace/Workspace";
 import { useAppStore, api, getServerUrl, discoverServerPort, type Task } from "./stores/app";
 import { useCommandPaletteStore } from "./stores/command-palette";
 import { useWorkspaceStore } from "./stores/workspace";
+import { useShortcutsStore, matchesShortcut } from "./stores/shortcuts";
 import { commandRegistry } from "./lib/commands/registry";
 import { createDefaultCommands } from "./lib/commands/default-commands";
 import { initSemanticSearch } from "./hooks/useSemanticSearch";
@@ -110,15 +112,31 @@ export function App() {
     return () => clearInterval(interval);
   }, [serverReady, refreshAgentStatus, serverOffline]);
 
-  // Global keyboard shortcuts
+  // Global keyboard shortcuts - uses shortcuts store as source of truth
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Don't capture shortcuts when typing in inputs (except for Escape and some global shortcuts)
       const target = e.target as HTMLElement;
       const isInInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+      const isInTerminal = target.closest('.xterm-container') !== null;
 
-      // Escape: close palette > restore maximized > clear focus
+      // Get shortcuts from store
+      const shortcutsStore = useShortcutsStore.getState();
+      const getShortcut = shortcutsStore.getShortcut;
+
+      // Escape: blur input > close shortcuts menu > close palette > restore maximized > clear focus
       if (e.key === 'Escape') {
+        // First, blur any focused input
+        if (isInInput && document.activeElement instanceof HTMLElement) {
+          e.preventDefault();
+          document.activeElement.blur();
+          return;
+        }
+        // Close shortcuts menu
+        if (shortcutsStore.isMenuOpen) {
+          e.preventDefault();
+          shortcutsStore.setMenuOpen(false);
+          return;
+        }
         if (commandPalette.isOpen) {
           e.preventDefault();
           commandPalette.close();
@@ -131,34 +149,92 @@ export function App() {
           useWorkspaceStore.getState().setMaximizedWidget(null);
           return;
         }
-        // If a widget is focused and not in an input, clear focus
+        // If a widget is focused, clear focus
         const focusedWidgetId = useWorkspaceStore.getState().focusedWidgetId;
-        if (focusedWidgetId && !isInInput) {
+        if (focusedWidgetId) {
           e.preventDefault();
           useWorkspaceStore.getState().setFocusedWidget(null, null);
           return;
         }
+        return;
       }
 
-      // Cmd/Ctrl + K: Toggle command palette
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      // Command palette shortcuts (work even when in input)
+      const cmdPaletteShortcut = getShortcut('command-palette-toggle');
+      const cmdPaletteAltShortcut = getShortcut('command-palette-toggle-alt');
+
+      if (cmdPaletteShortcut && matchesShortcut(e, cmdPaletteShortcut)) {
         e.preventDefault();
+        if (shortcutsStore.isMenuOpen) {
+          shortcutsStore.setMenuOpen(false);
+        }
         commandPalette.toggle();
         return;
       }
 
-      // Cmd/Ctrl + N: New Terminal (opens palette with subcommand)
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 'n' && !isInInput) {
+      if (cmdPaletteAltShortcut && matchesShortcut(e, cmdPaletteAltShortcut)) {
+        e.preventDefault();
+        if (shortcutsStore.isMenuOpen) {
+          shortcutsStore.setMenuOpen(false);
+        }
+        commandPalette.toggle();
+        return;
+      }
+
+      // Show keyboard shortcuts menu (works even when in input)
+      const showShortcutsShortcut = getShortcut('show-shortcuts');
+      if (showShortcutsShortcut && matchesShortcut(e, showShortcutsShortcut)) {
+        e.preventDefault();
+        if (commandPalette.isOpen) {
+          commandPalette.close();
+        }
+        shortcutsStore.toggleMenu();
+        return;
+      }
+
+      // Widget navigation shortcuts (CMD+H/J/K/L) - work even when in input
+      const focusLeftShortcut = getShortcut('focus-left');
+      const focusDownShortcut = getShortcut('focus-down');
+      const focusUpShortcut = getShortcut('focus-up');
+      const focusRightShortcut = getShortcut('focus-right');
+
+      if (focusLeftShortcut && matchesShortcut(e, focusLeftShortcut)) {
+        e.preventDefault();
+        useWorkspaceStore.getState().moveFocus('left');
+        return;
+      }
+      if (focusDownShortcut && matchesShortcut(e, focusDownShortcut)) {
+        e.preventDefault();
+        useWorkspaceStore.getState().moveFocus('down');
+        return;
+      }
+      if (focusUpShortcut && matchesShortcut(e, focusUpShortcut)) {
+        e.preventDefault();
+        useWorkspaceStore.getState().moveFocus('up');
+        return;
+      }
+      if (focusRightShortcut && matchesShortcut(e, focusRightShortcut)) {
+        e.preventDefault();
+        useWorkspaceStore.getState().moveFocus('right');
+        return;
+      }
+
+      // The following shortcuts don't work when typing in inputs
+      if (isInInput) return;
+
+      // New Console shortcut
+      const newConsoleShortcut = getShortcut('new-console');
+      if (newConsoleShortcut && matchesShortcut(e, newConsoleShortcut)) {
         e.preventDefault();
         commandPalette.open({ preselectedCommandId: 'new-terminal' });
         return;
       }
 
-      // Cmd/Ctrl + Shift + N: Create Task (opens palette in input mode)
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'N' && !isInInput) {
+      // Create Task shortcut
+      const createTaskShortcut = getShortcut('create-task');
+      if (createTaskShortcut && matchesShortcut(e, createTaskShortcut)) {
         e.preventDefault();
         commandPalette.open();
-        // Find and execute the create-task command to enter input mode
         const createTaskCmd = commandRegistry.getById('create-task');
         if (createTaskCmd && createTaskCmd.action.type === 'input') {
           commandPalette.enterInputMode(
@@ -169,34 +245,58 @@ export function App() {
         return;
       }
 
-      // Cmd/Ctrl + W: Close focused console
-      if ((e.metaKey || e.ctrlKey) && e.key === 'w' && !isInInput) {
+      // Close Widget shortcut
+      const closeWidgetShortcut = getShortcut('close-widget');
+      if (closeWidgetShortcut && matchesShortcut(e, closeWidgetShortcut)) {
         e.preventDefault();
         useWorkspaceStore.getState().closeFocusedConsole();
         return;
       }
 
-      // Cmd/Ctrl + Enter: Toggle maximize focused widget
-      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && !isInInput) {
+      // Maximize Widget shortcut
+      const maximizeWidgetShortcut = getShortcut('maximize-widget');
+      if (maximizeWidgetShortcut && matchesShortcut(e, maximizeWidgetShortcut)) {
         e.preventDefault();
         useWorkspaceStore.getState().toggleMaximizeFocusedWidget();
         return;
       }
 
-      // Cmd/Ctrl + Shift + D: Toggle demo view
+      // Cmd/Ctrl + Shift + D: Toggle demo view (hardcoded, not customizable)
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'D') {
         e.preventDefault();
         setView(view === 'demo' ? 'home' : 'demo');
         return;
       }
 
-      // Arrow key navigation (only when not in input and palette is closed)
-      if (!isInInput && !commandPalette.isOpen) {
+      // Arrow key navigation (only when palette is closed)
+      if (!commandPalette.isOpen && !shortcutsStore.isMenuOpen) {
         if (e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
           e.preventDefault();
           const direction = e.key.replace('Arrow', '').toLowerCase() as 'up' | 'down' | 'left' | 'right';
           useWorkspaceStore.getState().moveFocus(direction);
           return;
+        }
+      }
+
+      // Auto-focus input when typing without CMD in terminal/console
+      if (!e.metaKey && !e.ctrlKey && !e.altKey && !isInTerminal) {
+        const focusedWidgetId = useWorkspaceStore.getState().focusedWidgetId;
+        const focusedWidgetType = useWorkspaceStore.getState().focusedWidgetType;
+
+        // Only for console widgets (not terminals which use xterm)
+        if (focusedWidgetId && focusedWidgetType === 'agent-console') {
+          // Check if it's a printable character
+          if (e.key.length === 1 && !e.key.match(/^[F]\d+$/)) {
+            // Find the chat input in the focused console and focus it
+            const consoleElement = document.querySelector(`[data-console-id="${focusedWidgetId}"]`);
+            if (consoleElement) {
+              const textarea = consoleElement.querySelector('textarea');
+              if (textarea) {
+                textarea.focus();
+                return;
+              }
+            }
+          }
         }
       }
     };
@@ -300,6 +400,7 @@ export function App() {
         )}
         <Workspace />
         <CommandPalette />
+        <ShortcutsMenu />
       </div>
     );
   }
@@ -453,6 +554,9 @@ export function App() {
 
       {/* Command Palette Modal */}
       <CommandPalette />
+
+      {/* Keyboard Shortcuts Menu */}
+      <ShortcutsMenu />
     </div>
   );
 }

--- a/packages/ui/src/components/shortcuts/ShortcutsMenu.tsx
+++ b/packages/ui/src/components/shortcuts/ShortcutsMenu.tsx
@@ -1,0 +1,325 @@
+/**
+ * ShortcutsMenu - Modal for viewing and editing keyboard shortcuts
+ */
+
+import { useCallback, useState, useRef, useEffect } from 'react';
+import { X, RotateCcw, Keyboard, Check, AlertTriangle } from 'lucide-react';
+import {
+  useShortcutsStore,
+  SHORTCUT_CATEGORY_LABELS,
+  type Shortcut,
+  type ShortcutCategory,
+  type ModifierKey,
+  generateDisplayString,
+} from '../../stores/shortcuts';
+
+// ============================================================================
+// SHORTCUT ITEM COMPONENT
+// ============================================================================
+
+interface ShortcutItemProps {
+  shortcut: Shortcut;
+  isEditing: boolean;
+  onStartEdit: () => void;
+  onSave: (key: string, modifiers: ModifierKey[]) => void;
+  onCancel: () => void;
+  onReset: () => void;
+  isCustomized: boolean;
+}
+
+function ShortcutItem({
+  shortcut,
+  isEditing,
+  onStartEdit,
+  onSave,
+  onCancel,
+  onReset,
+  isCustomized,
+}: ShortcutItemProps) {
+  const [capturedKey, setCapturedKey] = useState<string | null>(null);
+  const [capturedModifiers, setCapturedModifiers] = useState<ModifierKey[]>([]);
+  const inputRef = useRef<HTMLDivElement>(null);
+
+  // Auto-focus the input when editing starts
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
+
+  // Reset captured state when editing starts
+  useEffect(() => {
+    if (isEditing) {
+      setCapturedKey(null);
+      setCapturedModifiers([]);
+    }
+  }, [isEditing]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Escape cancels editing
+    if (e.key === 'Escape') {
+      onCancel();
+      return;
+    }
+
+    // Capture modifiers
+    const modifiers: ModifierKey[] = [];
+    if (e.metaKey) modifiers.push('meta');
+    if (e.ctrlKey) modifiers.push('ctrl');
+    if (e.altKey) modifiers.push('alt');
+    if (e.shiftKey) modifiers.push('shift');
+
+    // Don't capture if only modifier keys are pressed
+    if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) {
+      setCapturedModifiers(modifiers);
+      return;
+    }
+
+    // Capture the key
+    setCapturedKey(e.key);
+    setCapturedModifiers(modifiers);
+  }, [onCancel]);
+
+  const handleSave = useCallback(() => {
+    if (capturedKey) {
+      onSave(capturedKey, capturedModifiers);
+    }
+  }, [capturedKey, capturedModifiers, onSave]);
+
+  const displayString = shortcut.displayString || generateDisplayString(shortcut.key, shortcut.modifiers);
+  const newDisplayString = capturedKey ? generateDisplayString(capturedKey, capturedModifiers) : null;
+
+  return (
+    <div
+      className={`flex items-center justify-between py-2 px-3 rounded-lg transition-colors ${
+        isEditing ? 'bg-zinc-800' : 'hover:bg-zinc-800/50'
+      } ${shortcut.enabled === false ? 'opacity-50' : ''}`}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-zinc-200">{shortcut.label}</span>
+          {isCustomized && (
+            <span className="text-[10px] px-1.5 py-0.5 bg-violet-500/20 text-violet-400 rounded">
+              Modified
+            </span>
+          )}
+          {shortcut.enabled === false && (
+            <span className="text-[10px] px-1.5 py-0.5 bg-zinc-700 text-zinc-500 rounded">
+              Disabled
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-zinc-500 truncate">{shortcut.description}</p>
+      </div>
+
+      <div className="flex items-center gap-2 ml-4">
+        {isEditing ? (
+          <>
+            <div
+              ref={inputRef}
+              tabIndex={0}
+              onKeyDown={handleKeyDown}
+              className="px-3 py-1.5 bg-zinc-900 border border-violet-500 rounded text-sm font-mono text-zinc-200 min-w-[100px] text-center focus:outline-none ring-1 ring-violet-500/50"
+            >
+              {newDisplayString || 'Press keys...'}
+            </div>
+            <button
+              onClick={handleSave}
+              disabled={!capturedKey}
+              className="p-1.5 text-green-400 hover:bg-green-500/20 rounded disabled:opacity-30 disabled:cursor-not-allowed"
+              title="Save"
+            >
+              <Check className="w-4 h-4" />
+            </button>
+            <button
+              onClick={onCancel}
+              className="p-1.5 text-zinc-400 hover:bg-zinc-700 rounded"
+              title="Cancel"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </>
+        ) : (
+          <>
+            <kbd
+              className={`px-2 py-1 text-xs font-mono rounded ${
+                shortcut.customizable !== false
+                  ? 'bg-zinc-800 text-zinc-300 cursor-pointer hover:bg-zinc-700'
+                  : 'bg-zinc-900 text-zinc-500 cursor-default'
+              }`}
+              onClick={() => shortcut.customizable !== false && onStartEdit()}
+              title={shortcut.customizable !== false ? 'Click to edit' : 'Cannot be customized'}
+            >
+              {displayString}
+            </kbd>
+            {isCustomized && (
+              <button
+                onClick={onReset}
+                className="p-1 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 rounded"
+                title="Reset to default"
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// SHORTCUTS MENU COMPONENT
+// ============================================================================
+
+export function ShortcutsMenu() {
+  const {
+    isMenuOpen,
+    setMenuOpen,
+    getAllShortcuts,
+    getShortcutsByCategory,
+    customizeShortcut,
+    resetShortcut,
+    resetAllShortcuts,
+    isCustomized,
+  } = useShortcutsStore();
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+
+  const handleClose = useCallback(() => {
+    setMenuOpen(false);
+    setEditingId(null);
+  }, [setMenuOpen]);
+
+  const handleOverlayClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      handleClose();
+    }
+  }, [handleClose]);
+
+  const handleSave = useCallback((id: string, key: string, modifiers: ModifierKey[]) => {
+    customizeShortcut(id, { key, modifiers });
+    setEditingId(null);
+  }, [customizeShortcut]);
+
+  const handleReset = useCallback((id: string) => {
+    resetShortcut(id);
+  }, [resetShortcut]);
+
+  const handleResetAll = useCallback(() => {
+    resetAllShortcuts();
+    setShowResetConfirm(false);
+  }, [resetAllShortcuts]);
+
+  if (!isMenuOpen) return null;
+
+  // Group shortcuts by category
+  const categories: ShortcutCategory[] = ['command', 'navigation', 'console', 'terminal', 'layout', 'general'];
+
+  const hasAnyCustomizations = getAllShortcuts().some(s => isCustomized(s.id));
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-start justify-center pt-[10vh] z-50"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-zinc-900 border border-zinc-700 rounded-xl w-full max-w-2xl overflow-hidden shadow-2xl max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="px-4 py-3 border-b border-zinc-800 flex items-center justify-between flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <Keyboard className="w-5 h-5 text-violet-400" />
+            <h2 className="text-lg font-semibold text-zinc-100">Keyboard Shortcuts</h2>
+          </div>
+          <div className="flex items-center gap-2">
+            {hasAnyCustomizations && (
+              showResetConfirm ? (
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="text-zinc-400">Reset all?</span>
+                  <button
+                    onClick={handleResetAll}
+                    className="px-2 py-1 bg-red-500/20 text-red-400 hover:bg-red-500/30 rounded"
+                  >
+                    Yes
+                  </button>
+                  <button
+                    onClick={() => setShowResetConfirm(false)}
+                    className="px-2 py-1 bg-zinc-800 text-zinc-400 hover:bg-zinc-700 rounded"
+                  >
+                    No
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setShowResetConfirm(true)}
+                  className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 rounded-lg flex items-center gap-1.5"
+                >
+                  <RotateCcw className="w-3.5 h-3.5" />
+                  Reset All
+                </button>
+              )
+            )}
+            <button
+              onClick={handleClose}
+              className="p-1.5 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 rounded-lg"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-6">
+          {/* Help text */}
+          <div className="flex items-start gap-2 p-3 bg-zinc-800/50 rounded-lg text-sm">
+            <AlertTriangle className="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5" />
+            <p className="text-zinc-400">
+              Click on a shortcut key to customize it. Press the new key combination you want to use, then click the checkmark to save.
+              Some shortcuts cannot be customized.
+            </p>
+          </div>
+
+          {categories.map(category => {
+            const shortcuts = getShortcutsByCategory(category);
+            if (shortcuts.length === 0) return null;
+
+            return (
+              <div key={category}>
+                <h3 className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-2">
+                  {SHORTCUT_CATEGORY_LABELS[category]}
+                </h3>
+                <div className="space-y-1">
+                  {shortcuts.map(shortcut => (
+                    <ShortcutItem
+                      key={shortcut.id}
+                      shortcut={shortcut}
+                      isEditing={editingId === shortcut.id}
+                      onStartEdit={() => setEditingId(shortcut.id)}
+                      onSave={(key, modifiers) => handleSave(shortcut.id, key, modifiers)}
+                      onCancel={() => setEditingId(null)}
+                      onReset={() => handleReset(shortcut.id)}
+                      isCustomized={isCustomized(shortcut.id)}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-2 border-t border-zinc-800 text-xs text-zinc-500 flex items-center justify-between flex-shrink-0">
+          <span>Press <kbd className="bg-zinc-800 px-1 rounded">Esc</kbd> to close</span>
+          <span>
+            <kbd className="bg-zinc-800 px-1 rounded">⌘</kbd> + <kbd className="bg-zinc-800 px-1 rounded">/</kbd> to toggle
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ShortcutsMenu;

--- a/packages/ui/src/components/shortcuts/index.ts
+++ b/packages/ui/src/components/shortcuts/index.ts
@@ -1,0 +1,1 @@
+export { ShortcutsMenu } from './ShortcutsMenu';

--- a/packages/ui/src/components/workspace/Workspace.tsx
+++ b/packages/ui/src/components/workspace/Workspace.tsx
@@ -863,6 +863,7 @@ function AgentConsoleWidget({
   return (
     <div
       className={`h-full bg-[#0d1117] border rounded-lg flex flex-col overflow-hidden transition-all duration-150 ${getBorderClass()}`}
+      data-console-id={consoleState.id}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onContextMenu={handleContextMenu}
@@ -2031,11 +2032,16 @@ export function Workspace() {
 
   // Sync widgets to workspace store for arrow key navigation
   useEffect(() => {
-    const widgets: Array<{ id: string; type: 'agent-console' | 'tasks' | 'agent-status' }> = [];
+    const widgets: Array<{ id: string; type: 'agent-console' | 'tasks' | 'agent-status' | 'terminal' }> = [];
 
-    // Add terminals
+    // Add agent consoles
     terminals.forEach(t => {
       widgets.push({ id: t.id, type: 'agent-console' });
+    });
+
+    // Add real terminals
+    realTerminals.forEach(t => {
+      widgets.push({ id: t.id, type: 'terminal' });
     });
 
     // Add tasks widget if visible
@@ -2049,7 +2055,7 @@ export function Workspace() {
     }
 
     useWorkspaceStore.getState().setWidgets(widgets);
-  }, [terminals, tasksVisible, showAgentStatus]);
+  }, [terminals, realTerminals, tasksVisible, showAgentStatus]);
 
   // Initialize/update layout tree when terminals change
   useEffect(() => {

--- a/packages/ui/src/lib/commands/default-commands.ts
+++ b/packages/ui/src/lib/commands/default-commands.ts
@@ -17,10 +17,12 @@ import {
   Grid2X2,
   RotateCcw,
   Terminal,
+  Keyboard,
 } from 'lucide-react';
 import type { Command } from './types';
 import { useWorkspaceStore, type LayoutWidgetInfo } from '../../stores/workspace';
 import { useAppStore, api, getServerUrl } from '../../stores/app';
+import { useShortcutsStore } from '../../stores/shortcuts';
 
 /**
  * Get the agent icon based on type/name
@@ -483,6 +485,25 @@ export function createDefaultCommands(): Command[] {
               console.error('Failed to close terminal:', err);
             }
           }
+        },
+      },
+    },
+
+    // ========================================
+    // Settings / Help Commands
+    // ========================================
+    {
+      id: 'keyboard-shortcuts',
+      label: 'Keyboard Shortcuts',
+      description: 'View and customize keyboard shortcuts',
+      category: 'navigation',
+      icon: Keyboard,
+      shortcut: '⌘/',
+      keywords: ['shortcuts', 'keys', 'keybindings', 'hotkeys', 'keyboard', 'help'],
+      action: {
+        type: 'execute',
+        handler: () => {
+          useShortcutsStore.getState().setMenuOpen(true);
         },
       },
     },

--- a/packages/ui/src/stores/shortcuts.ts
+++ b/packages/ui/src/stores/shortcuts.ts
@@ -1,0 +1,424 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/** Modifier keys that can be used in shortcuts */
+export type ModifierKey = 'meta' | 'ctrl' | 'alt' | 'shift';
+
+/** A keyboard shortcut definition */
+export interface Shortcut {
+  /** Unique identifier for this shortcut */
+  id: string;
+  /** Human-readable name for the shortcut */
+  label: string;
+  /** Description of what the shortcut does */
+  description: string;
+  /** Category for grouping shortcuts */
+  category: ShortcutCategory;
+  /** The key to press (e.g., 'k', 'Enter', 'ArrowUp') */
+  key: string;
+  /** Required modifier keys */
+  modifiers: ModifierKey[];
+  /** Display string (e.g., '⌘K', '⌘⇧N') - auto-generated if not provided */
+  displayString?: string;
+  /** Whether this shortcut can be customized by the user */
+  customizable?: boolean;
+  /** Whether this shortcut is enabled */
+  enabled?: boolean;
+}
+
+/** Categories for organizing shortcuts */
+export type ShortcutCategory =
+  | 'navigation'    // Moving between widgets
+  | 'command'       // Command palette related
+  | 'console'       // Console actions
+  | 'terminal'      // Terminal actions
+  | 'layout'        // Layout management
+  | 'general';      // General shortcuts
+
+/** User customizations for shortcuts */
+export interface ShortcutCustomization {
+  /** New key binding */
+  key?: string;
+  /** New modifiers */
+  modifiers?: ModifierKey[];
+  /** Whether the shortcut is enabled */
+  enabled?: boolean;
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/** Generate a display string for a shortcut */
+export function generateDisplayString(key: string, modifiers: ModifierKey[]): string {
+  const symbols: Record<ModifierKey, string> = {
+    meta: '⌘',
+    ctrl: '⌃',
+    alt: '⌥',
+    shift: '⇧',
+  };
+
+  const keySymbols: Record<string, string> = {
+    'Enter': '↵',
+    'ArrowUp': '↑',
+    'ArrowDown': '↓',
+    'ArrowLeft': '←',
+    'ArrowRight': '→',
+    'Escape': 'Esc',
+    'Backspace': '⌫',
+    'Delete': '⌦',
+    'Tab': '⇥',
+    ' ': 'Space',
+  };
+
+  const modifierStr = modifiers
+    .sort((a, b) => {
+      const order: ModifierKey[] = ['ctrl', 'alt', 'shift', 'meta'];
+      return order.indexOf(a) - order.indexOf(b);
+    })
+    .map(m => symbols[m])
+    .join('');
+
+  const keyStr = keySymbols[key] || key.toUpperCase();
+  return modifierStr + keyStr;
+}
+
+/** Check if a keyboard event matches a shortcut */
+export function matchesShortcut(event: KeyboardEvent, shortcut: Shortcut): boolean {
+  if (shortcut.enabled === false) return false;
+
+  // Check key (case-insensitive for letter keys)
+  const eventKey = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+  const shortcutKey = shortcut.key.length === 1 ? shortcut.key.toLowerCase() : shortcut.key;
+  if (eventKey !== shortcutKey) return false;
+
+  // Check modifiers
+  const hasCtrl = event.ctrlKey;
+  const hasMeta = event.metaKey;
+  const hasAlt = event.altKey;
+  const hasShift = event.shiftKey;
+
+  const needsCtrl = shortcut.modifiers.includes('ctrl');
+  const needsMeta = shortcut.modifiers.includes('meta');
+  const needsAlt = shortcut.modifiers.includes('alt');
+  const needsShift = shortcut.modifiers.includes('shift');
+
+  // For meta/ctrl, allow either (cross-platform support)
+  const metaOrCtrl = hasMeta || hasCtrl;
+  const needsMetaOrCtrl = needsMeta || needsCtrl;
+
+  if (needsMetaOrCtrl !== metaOrCtrl) return false;
+  if (needsAlt !== hasAlt) return false;
+  if (needsShift !== hasShift) return false;
+
+  return true;
+}
+
+// ============================================================================
+// DEFAULT SHORTCUTS
+// ============================================================================
+
+export const DEFAULT_SHORTCUTS: Shortcut[] = [
+  // Command Palette (CMD+P is primary, CMD+Shift+K is alternative)
+  {
+    id: 'command-palette-toggle',
+    label: 'Open Command Palette',
+    description: 'Toggle the command palette',
+    category: 'command',
+    key: 'p',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+  {
+    id: 'command-palette-toggle-alt',
+    label: 'Open Command Palette (Alt)',
+    description: 'Toggle the command palette with Shift+K',
+    category: 'command',
+    key: 'k',
+    modifiers: ['meta', 'shift'],
+    customizable: true,
+  },
+
+  // Widget Navigation (Vim-style with CMD)
+  {
+    id: 'focus-left',
+    label: 'Focus Left',
+    description: 'Move focus to the widget on the left',
+    category: 'navigation',
+    key: 'h',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+  {
+    id: 'focus-down',
+    label: 'Focus Down',
+    description: 'Move focus to the widget below',
+    category: 'navigation',
+    key: 'j',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+  {
+    id: 'focus-up',
+    label: 'Focus Up',
+    description: 'Move focus to the widget above',
+    category: 'navigation',
+    key: 'k',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+  {
+    id: 'focus-right',
+    label: 'Focus Right',
+    description: 'Move focus to the widget on the right',
+    category: 'navigation',
+    key: 'l',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+
+  // Console/Terminal Actions
+  {
+    id: 'new-console',
+    label: 'New Console',
+    description: 'Open a new agent console',
+    category: 'console',
+    key: 'n',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+  {
+    id: 'new-terminal',
+    label: 'New Terminal',
+    description: 'Open a new terminal',
+    category: 'terminal',
+    key: 't',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+  {
+    id: 'close-widget',
+    label: 'Close Widget',
+    description: 'Close the focused widget',
+    category: 'general',
+    key: 'w',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+  {
+    id: 'maximize-widget',
+    label: 'Maximize/Restore Widget',
+    description: 'Toggle maximize for the focused widget',
+    category: 'layout',
+    key: 'Enter',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+  {
+    id: 'create-task',
+    label: 'Create Task',
+    description: 'Create a new task',
+    category: 'general',
+    key: 'n',
+    modifiers: ['meta', 'shift'],
+    customizable: true,
+  },
+
+  // Escape actions (not customizable)
+  {
+    id: 'escape',
+    label: 'Escape',
+    description: 'Close palette / restore maximized / clear focus',
+    category: 'general',
+    key: 'Escape',
+    modifiers: [],
+    customizable: false,
+  },
+
+  // Arrow key navigation (keeping for compatibility)
+  {
+    id: 'arrow-up',
+    label: 'Navigate Up',
+    description: 'Move focus up (when no widget focused)',
+    category: 'navigation',
+    key: 'ArrowUp',
+    modifiers: [],
+    customizable: false,
+  },
+  {
+    id: 'arrow-down',
+    label: 'Navigate Down',
+    description: 'Move focus down (when no widget focused)',
+    category: 'navigation',
+    key: 'ArrowDown',
+    modifiers: [],
+    customizable: false,
+  },
+  {
+    id: 'arrow-left',
+    label: 'Navigate Left',
+    description: 'Move focus left (when no widget focused)',
+    category: 'navigation',
+    key: 'ArrowLeft',
+    modifiers: [],
+    customizable: false,
+  },
+  {
+    id: 'arrow-right',
+    label: 'Navigate Right',
+    description: 'Move focus right (when no widget focused)',
+    category: 'navigation',
+    key: 'ArrowRight',
+    modifiers: [],
+    customizable: false,
+  },
+
+  // View shortcuts menu
+  {
+    id: 'show-shortcuts',
+    label: 'Keyboard Shortcuts',
+    description: 'Show keyboard shortcuts menu',
+    category: 'general',
+    key: '/',
+    modifiers: ['meta'],
+    customizable: true,
+  },
+];
+
+// ============================================================================
+// STORE
+// ============================================================================
+
+interface ShortcutsState {
+  /** User customizations (sparse - only stores differences from defaults) */
+  customizations: Record<string, ShortcutCustomization>;
+
+  /** Whether the shortcuts menu is open */
+  isMenuOpen: boolean;
+
+  /** Get a shortcut by ID (with user customizations applied) */
+  getShortcut: (id: string) => Shortcut | undefined;
+
+  /** Get all shortcuts (with user customizations applied) */
+  getAllShortcuts: () => Shortcut[];
+
+  /** Get shortcuts by category */
+  getShortcutsByCategory: (category: ShortcutCategory) => Shortcut[];
+
+  /** Customize a shortcut */
+  customizeShortcut: (id: string, customization: ShortcutCustomization) => void;
+
+  /** Reset a shortcut to its default */
+  resetShortcut: (id: string) => void;
+
+  /** Reset all shortcuts to defaults */
+  resetAllShortcuts: () => void;
+
+  /** Check if a shortcut has been customized */
+  isCustomized: (id: string) => boolean;
+
+  /** Open/close shortcuts menu */
+  setMenuOpen: (open: boolean) => void;
+  toggleMenu: () => void;
+
+  /** Find shortcut by keyboard event */
+  findMatchingShortcut: (event: KeyboardEvent) => Shortcut | undefined;
+}
+
+export const useShortcutsStore = create<ShortcutsState>()(
+  persist(
+    (set, get) => ({
+      customizations: {},
+      isMenuOpen: false,
+
+      getShortcut: (id) => {
+        const defaultShortcut = DEFAULT_SHORTCUTS.find(s => s.id === id);
+        if (!defaultShortcut) return undefined;
+
+        const customization = get().customizations[id];
+        if (!customization) {
+          return {
+            ...defaultShortcut,
+            displayString: defaultShortcut.displayString || generateDisplayString(defaultShortcut.key, defaultShortcut.modifiers),
+          };
+        }
+
+        const merged: Shortcut = {
+          ...defaultShortcut,
+          key: customization.key ?? defaultShortcut.key,
+          modifiers: customization.modifiers ?? defaultShortcut.modifiers,
+          enabled: customization.enabled ?? defaultShortcut.enabled,
+        };
+        merged.displayString = generateDisplayString(merged.key, merged.modifiers);
+        return merged;
+      },
+
+      getAllShortcuts: () => {
+        return DEFAULT_SHORTCUTS.map(s => get().getShortcut(s.id)!);
+      },
+
+      getShortcutsByCategory: (category) => {
+        return get().getAllShortcuts().filter(s => s.category === category);
+      },
+
+      customizeShortcut: (id, customization) => {
+        const defaultShortcut = DEFAULT_SHORTCUTS.find(s => s.id === id);
+        if (!defaultShortcut || defaultShortcut.customizable === false) return;
+
+        set(state => ({
+          customizations: {
+            ...state.customizations,
+            [id]: {
+              ...state.customizations[id],
+              ...customization,
+            },
+          },
+        }));
+      },
+
+      resetShortcut: (id) => {
+        set(state => {
+          const { [id]: _, ...rest } = state.customizations;
+          return { customizations: rest };
+        });
+      },
+
+      resetAllShortcuts: () => {
+        set({ customizations: {} });
+      },
+
+      isCustomized: (id) => {
+        return !!get().customizations[id];
+      },
+
+      setMenuOpen: (open) => set({ isMenuOpen: open }),
+      toggleMenu: () => set(state => ({ isMenuOpen: !state.isMenuOpen })),
+
+      findMatchingShortcut: (event) => {
+        const shortcuts = get().getAllShortcuts();
+        return shortcuts.find(s => matchesShortcut(event, s));
+      },
+    }),
+    {
+      name: 'shortcuts-storage',
+      partialize: (state) => ({ customizations: state.customizations }),
+    }
+  )
+);
+
+// ============================================================================
+// CATEGORY LABELS
+// ============================================================================
+
+export const SHORTCUT_CATEGORY_LABELS: Record<ShortcutCategory, string> = {
+  navigation: 'Navigation',
+  command: 'Command Palette',
+  console: 'Console',
+  terminal: 'Terminal',
+  layout: 'Layout',
+  general: 'General',
+};

--- a/packages/ui/src/stores/workspace.ts
+++ b/packages/ui/src/stores/workspace.ts
@@ -670,16 +670,28 @@ export const useWorkspaceStore = create<WorkspaceState>()((set, get) => ({
   setShowAgentStatus: (show) => set({ showAgentStatus: show }),
   setTasksVisible: (visible) => set({ tasksVisible: visible }),
 
-  // Arrow key navigation
+  // Arrow key / shortcut navigation
   moveFocus: (direction) => {
     const { widgets, focusedWidgetId } = get();
     if (widgets.length === 0) return;
+
+    // Helper to blur any active input and set focus
+    const blurAndSetFocus = (id: string, type: WidgetType) => {
+      // Blur any currently focused DOM element (e.g., text inputs) when navigating
+      if (document.activeElement instanceof HTMLElement) {
+        const tagName = document.activeElement.tagName;
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA' || document.activeElement.isContentEditable) {
+          document.activeElement.blur();
+        }
+      }
+      set({ focusedWidgetId: id, focusedWidgetType: type });
+    };
 
     // If nothing focused, focus the first widget
     if (!focusedWidgetId) {
       const first = widgets[0];
       if (first) {
-        set({ focusedWidgetId: first.id, focusedWidgetType: first.type });
+        blurAndSetFocus(first.id, first.type);
       }
       return;
     }
@@ -688,7 +700,7 @@ export const useWorkspaceStore = create<WorkspaceState>()((set, get) => ({
     if (currentIndex === -1) {
       const first = widgets[0];
       if (first) {
-        set({ focusedWidgetId: first.id, focusedWidgetType: first.type });
+        blurAndSetFocus(first.id, first.type);
       }
       return;
     }
@@ -703,7 +715,7 @@ export const useWorkspaceStore = create<WorkspaceState>()((set, get) => ({
 
     const nextWidget = widgets[nextIndex];
     if (nextWidget) {
-      set({ focusedWidgetId: nextWidget.id, focusedWidgetType: nextWidget.type });
+      blurAndSetFocus(nextWidget.id, nextWidget.type);
     }
   },
 


### PR DESCRIPTION
## Summary
- Add shortcuts menu (CMD+/) for viewing and editing keyboard shortcuts
- Change default command palette shortcut from CMD+K to CMD+P
- Add CMD+Shift+K as alternative command palette shortcut
- Add vim-style widget navigation: CMD+H/J/K/L for left/down/up/right
- Include terminals in navigation alongside consoles, tasks, and status
- Allow navigation shortcuts to work even when text input is focused
- ESC blurs focused input before closing menus/clearing focus
- Persist shortcut customizations to localStorage

## Test plan
- [ ] Press CMD+/ to open shortcuts menu
- [ ] Verify CMD+P opens command palette
- [ ] Verify CMD+Shift+K also opens command palette
- [ ] Test CMD+H/J/K/L navigation between widgets including terminals
- [ ] Verify navigation works when text input is focused
- [ ] Test ESC blurs input first, then closes menus
- [ ] Customize a shortcut and verify it persists after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)